### PR TITLE
Add command to prepare android job later in workflow.

### DIFF
--- a/prepare-mobile-workflow/commands/prepare-android-job.yml
+++ b/prepare-mobile-workflow/commands/prepare-android-job.yml
@@ -1,0 +1,29 @@
+description: |
+  Prepares android job later in a workflow: attaches workspace, restore caches.
+
+parameters:
+  android_cache_version:
+    description: "Cache key (example \"v2\"). Could be used to invalidate cache."
+    type: string
+  gradle_cache_version:
+    description: "Cache key (example \"v2\"). Could be used to invalidate cache."
+    type: string
+  cache_modifier:
+    description: "Optional cache modifier. Useful to create several caches for the same dependencies file."
+    type: string
+    default: ""
+  dependencies_file:
+    description: "Path to the file that defines all project dependencies and their versions."
+    type: string
+
+steps:
+  - attach_workspace:
+      at: .
+  - restore-android-sdk-cache:
+      cache_version: << parameters.android_cache_version >>
+      cache_modifier: << parameters.cache_modifier >>
+      dependencies_file: << parameters.dependencies_file >>
+  - restore-gradle-cache:
+      cache_version: << parameters.gradle_cache_version >>
+      cache_modifier: << parameters.cache_modifier >>
+      dependencies_file: << parameters.dependencies_file >>


### PR DESCRIPTION
This command should be used in other workflow jobs to prepare them for execution:
- attaches saved repo
- restore android sdk cache
- restore gradle dependencies cache

Missed it in initial orb implementation.