### PR TITLE
Fix save android cache uses wrong paths.

### DIFF
--- a/prepare-mobile-workflow/commands/save-android-sdk-cache.yml
+++ b/prepare-mobile-workflow/commands/save-android-sdk-cache.yml
@@ -16,8 +16,10 @@ parameters:
 
 steps:
   - save_cache:
+      name: "Saving android cache"
       key: << parameters.cache_version >>-<< parameters.cache_modifier >>-android-sdk-{{ checksum << parameters.dependencies_file >> }}
       paths:
-        - $ANDROID_HOME/build-tools
-        - $ANDROID_HOME/platforms
-        - $ANDROID_HOME/platform-tools
+        # Taken from docker image ANDROID_HOME env variable
+        - ~/android-sdk/build-tools
+        - ~/android-sdk/platforms
+        - ~/android-sdk/platform-tools

--- a/prepare-mobile-workflow/commands/save-gradle-cache.yml
+++ b/prepare-mobile-workflow/commands/save-gradle-cache.yml
@@ -22,7 +22,7 @@ parameters:
 
 steps:
   - save_cache:
-      name: Save Gradle cache in PR
+      name: "Saving Gradle cache"
       key: << parameters.cache_version >>-<< parameters.cache_modifier >>-dependencies-{{ checksum << parameters.dependencies_file >> }}
       paths:
         - << parameters.gradle_caches_dir >>


### PR DESCRIPTION
Apparently CircleCI does not expand env variables in `path` declarations, though it is only said in `working_directory` description: https://circleci.com/docs/2.0/configuration-reference/#job_name

This PR changes android sdk directory path usage to direct.