### PR TITLE
Add missing working directory to alpine-git executor.

### DIFF
--- a/prepare-mobile-workflow/executors/alpine-git.yml
+++ b/prepare-mobile-workflow/executors/alpine-git.yml
@@ -1,4 +1,4 @@
 resource_class: small
-
+working_directory: /home/circleci/repo
 docker:
   - image: alpine/git


### PR DESCRIPTION
This leaded to git cache created with wrong paths, that could not be used in other jobs: https://circleci.com/gh/freeletics/fl-application-android/210349