### PR TITLE
Update prepare-mobile-workflow to support iOS.

### DIFF
--- a/mobile-shared-executors/ruby-git-small.yml
+++ b/mobile-shared-executors/ruby-git-small.yml
@@ -1,0 +1,21 @@
+parameters:
+  ruby_version:
+    type: string
+    default: "2.5"
+  working_directory:
+    type: string
+    default: /home/circleci/repo
+  bundler_version:
+    type: string
+    default: "2.0.2"
+  bundler_path:
+    type: string
+    default: vendor/bundle/2.5
+resource_class: small
+docker:
+  - image: circleci/ruby:<< parameters.ruby_version >>
+working_directory: << parameters.working_directory >>
+environment:
+  TERM: dumb
+  BUNDLER_VERSION: << parameters.bundler_version >>
+  BUNDLE_PATH: << parameters.bundler_path >>

--- a/prepare-mobile-workflow/commands/prepare-ios-job.yml
+++ b/prepare-mobile-workflow/commands/prepare-ios-job.yml
@@ -1,0 +1,36 @@
+description: |
+  Prepares ios job later in a workflow: attaches workspace, restore caches.
+  Assumes executor already exposes BUNDLER_VERSION and BUNDLE_PATH env variables
+
+parameters:
+  native_extensions_cache_version:
+    description: "Cache key (example \"v2\"). Could be used to invalidate cache."
+    type: string
+  native-platform:
+    description: |
+      Ruby Native platform. For example, linux 64bit will be "x86_64-linux".
+      To get your current platform, execute "bundle platform"
+    type: string
+  native_extensions_cache_modifier:
+    description: "Optional cache modifier. Useful to create several caches for the same dependencies file."
+    type: string
+    default: ""
+  gemlock_file:
+    description: "Path to the Gemfile.lock file that defines all gems and their versions."
+    type: string
+  bundler_path:
+    description: "Path to the bundler gems installation directory."
+    type: string
+
+steps:
+  - attach_workspace:
+      at: .
+  - run:
+      name: Install bundler
+      command: gem install bundler
+  - sync-gems-native-extensions:
+      cache_version: << parameters.native_extensions_cache_version >>
+      native-platform: << parameters.native-platform >>
+      cache_modifier: << parameters.native_extensions_cache_modifier >>
+      gemlock_file: << parameters.gemlock_file >>
+      bundler_path: << parameters.bundler_path >>

--- a/prepare-mobile-workflow/commands/restore-gems-cache.yml
+++ b/prepare-mobile-workflow/commands/restore-gems-cache.yml
@@ -1,0 +1,18 @@
+description: "Restores previously saved gems."
+
+parameters:
+  cache_version:
+    description: "Cache key (example \"v2\"). Could be used to invalidate cache."
+    type: string
+  cache_modifier:
+    description: "Optional cache modifier. Useful to create several caches for the same dependencies file."
+    type: string
+    default: ""
+  gemlock_file:
+    description: "Path to the Gemfile.lock file that defines all gems and their versions."
+    type: string
+
+steps:
+  - restore_cache:
+      name: Restore gems cache
+      key: << parameters.cache_version >>-<< parameters.cache_modifier >>-gems-{{ checksum << parameters.gemlock_file >> }}

--- a/prepare-mobile-workflow/commands/save-gems-cache.yml
+++ b/prepare-mobile-workflow/commands/save-gems-cache.yml
@@ -1,0 +1,24 @@
+description: |
+  Saves into cache downloaded gems.
+
+parameters:
+  cache_version:
+    description: "Cache key (example \"v2\"). Could be used to invalidate cache."
+    type: string
+  cache_modifier:
+    description: "Optional cache modifier. Useful to create several caches for the same dependencies file."
+    type: string
+    default: ""
+  gemlock_file:
+    description: "Path to the Gemfile.lock file that defines all gem dependencies and their versions."
+    type: string
+  bundler_path:
+    description: "Path to the bundler gems installation directory."
+    type: string
+
+steps:
+  - save_cache:
+      name: "Saving gems cache"
+      key: << parameters.cache_version >>-<< parameters.cache_modifier >>-gems-{{ checksum << parameters.gemlock_file >> }}
+      paths:
+        - << parameters.bundler_path >>

--- a/prepare-mobile-workflow/commands/sync-gems-native-extensions.yml
+++ b/prepare-mobile-workflow/commands/sync-gems-native-extensions.yml
@@ -1,0 +1,39 @@
+description: |
+  Syncs installed gems and if they have missing native extension - install them.
+  Exists as a workaround for CircleCI cache could not use relative paths.
+
+parameters:
+  cache_version:
+    description: "Cache key (example \"v2\"). Could be used to invalidate cache."
+    type: string
+  native-platform:
+    description: |
+      Ruby Native platform. For example, linux 64bit will be "x86_64-linux".
+      To get your current platform, execute "bundle platform"
+    type: string
+  cache_modifier:
+    description: "Optional cache modifier. Useful to create several caches for the same dependencies file."
+    type: string
+    default: ""
+  gemlock_file:
+    description: "Path to the Gemfile.lock file that defines all gems and their versions."
+    type: string
+  bundler_path:
+    description: "Path to the bundler gems installation directory."
+    type: string
+
+steps:
+  - restore_cache:
+      name: Restore gems native extensions cache
+      key: << parameters.cache_version >>-<< parameters.cache_modifier >>-gems-extensions-<< parameters.native-platform >>-{{ checksum << parameters.gemlock_file >> }}
+  - run:
+      name: Sync extensions
+      command: |
+        if [ ! -d "<< parameters.bundler_path >>/extensions/<< parameters.native-platform >>" ]; then
+          bundle install;
+        fi
+  - save_cache:
+      name: Saves gems native extensions cache
+      key: << parameters.cache_version >>-<< parameters.cache_modifier >>-gems-extensions-<< parameters.native-platform >>-{{ checksum << parameters.gemlock_file >> }}
+      paths:
+        - << parameters.bundler_path >>/extensions/<< parameters.native-platform >>

--- a/prepare-mobile-workflow/executors/ruby-git-small.yml
+++ b/prepare-mobile-workflow/executors/ruby-git-small.yml
@@ -1,0 +1,1 @@
+../../mobile-shared-executors/ruby-git-small.yml

--- a/prepare-mobile-workflow/jobs/prepare-ios-workflow.yml
+++ b/prepare-mobile-workflow/jobs/prepare-ios-workflow.yml
@@ -1,0 +1,75 @@
+description: |
+  Prepares CI workflow for iOS builds later in this workflow. Followup jobs
+  should not do any checkout, but attach workspace and restore gem cache.
+
+parameters:
+  git_cache_version:
+    description: "Git cache key (example \"v2\"). Could be used to invalidate cache."
+    type: string
+    default: "v2"
+  gem_cache_version:
+    description: "Gem cache key (example \"v2\"). Could be used to invalidate cache."
+    type: string
+    default: "v3"
+  cache_modifier:
+    description: "Optional caches modifier. Useful to create several caches for the same dependencies file."
+    type: string
+    default: ""
+  gemlock_file:
+    description: "Path to the Gemfile.lock file that defines all gem dependencies and their versions."
+    type: string
+  sync_dependencies:
+    description: "Steps to sync gem dependencies."
+    type: steps
+    default: []
+  post-checkout-additional-steps:
+    description: "Optional steps to perform after checkout, but before saving to workspace."
+    type: steps
+    default: []
+  ruby_version:
+    description: "Version of ruby to use."
+    type: string
+    default: "2.5"
+  bundler_path:
+    description: "Path to store installed gems, default to 'vendor/bundle/<ruby-version>'"
+    type: string
+    default: vendor/bundle/2.5
+  bundler_version:
+    description: "Bundler version to use."
+    type: string
+    default: "2.0.2"
+  working_directory:
+    type: string
+    default: /home/circleci/repo
+
+executor:
+  name: ruby-git-small
+  working_directory: << parameters.working_directory >>
+  ruby_version: << parameters.ruby_version >>
+  bundler_version: << parameters.bundler_version >>
+  bundler_path: << parameters.bundler_path >>
+
+steps:
+  - checkout-from-git-cache:
+      cache_version: << parameters.git_cache_version >>
+  - run:
+      name: Removing .git folder
+      command: rm -rf .git/
+  - steps: << parameters.post-checkout-additional-steps >>
+  - restore-gems-cache:
+      cache_version: << parameters.gem_cache_version >>
+      cache_modifier: << parameters.cache_modifier >>
+      gemlock_file: << parameters.gemlock_file >>
+  - run:
+      name: Install bundler
+      command: gem install bundler
+  - steps: << parameters.sync_dependencies >>
+  - save-gems-cache:
+      cache_version: << parameters.gem_cache_version >>
+      cache_modifier: << parameters.cache_modifier >>
+      gemlock_file: << parameters.gemlock_file >>
+      bundler_path: << parameters.bundler_path >>
+  - persist_to_workspace:
+      root: .
+      paths:
+        - .


### PR DESCRIPTION
Add `prepare-ios-workflow` job that restores project files from git cache, syncs gems dependencies and then saves it to the workflow workspace. Job itself runs in the docker image.

Later jobs in workflow should use `prepare-ios-job` command to restore workspace for other job steps.
For `macos` executor it also syncs gems native extensions.

Related draft PR into iOS repo: https://github.com/freeletics/fl-application-ios/pull/7179