### PR TITLE
Install bundler to user directory.

### DIFF
--- a/prepare-mobile-workflow/commands/prepare-ios-job.yml
+++ b/prepare-mobile-workflow/commands/prepare-ios-job.yml
@@ -27,7 +27,10 @@ steps:
       at: .
   - run:
       name: Install bundler
-      command: gem install bundler
+      command: |
+        echo 'PATH="$(ruby -e '\''puts Gem.user_dir'\'')/bin:$PATH"' >> $BASH_ENV
+        source $BASH_ENV
+        gem install --user-install bundler
   - sync-gems-native-extensions:
       cache_version: << parameters.native_extensions_cache_version >>
       native-platform: << parameters.native-platform >>


### PR DESCRIPTION
Update to `prepare-workflow` orb to install bundler to local user dir in `prepare-ios-job` command.

Installing it system-wide is not encouraged when using images with newer XCode version.

Example of CI workflow that uses updated orb: https://circleci.com/workflow-run/1a657abe-0cdf-4f36-b2db-e23e49e8e2b3