### PR TITLE
Create circleci-macos

### DIFF
--- a/gradle-publish/executors/circleci-macos
+++ b/gradle-publish/executors/circleci-macos
@@ -1,0 +1,3 @@
+resource_class: medium
+macos: 
+      xcode: 11.3.1


### PR DESCRIPTION
Executor that can be used with `android-maven-publish` orb to build and publish kotlin multiplatform projects.