### PR TITLE
Including the Kaniko Publish orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ workflows:
           name: "Publish gradle-publish patch release"
           orb-name: freeletics/gradle-publish
           release: patch
+          publish-version-tag: false
           requires:
             - "Gradle-publish patch release"
       - "Gradle-publish minor release":
@@ -52,6 +53,7 @@ workflows:
           name: "Publish gradle-publish minor release"
           orb-name: freeletics/gradle-publish
           release: minor
+          publish-version-tag: false
           requires:
             - "Gradle-publish minor release"
       - "Gradle-publish major release":
@@ -63,6 +65,7 @@ workflows:
           name: "Publish gradle-publish major release"
           orb-name: freeletics/gradle-publish
           release: major
+          publish-version-tag: false
           requires:
             - "Gradle-publish major release"
 
@@ -89,6 +92,7 @@ workflows:
       - orb-tools/dev-promote-prod:
           name: "Publish prepare-mobile-workflow patch release"
           orb-name: freeletics/prepare-mobile-workflow
+          publish-version-tag: false
           release: patch
           requires:
             - "Prepare-mobile-workflow patch release"
@@ -100,6 +104,7 @@ workflows:
       - orb-tools/dev-promote-prod:
           name: "Publish prepare-mobile-workflow minor release"
           orb-name: freeletics/prepare-mobile-workflow
+          publish-version-tag: false
           release: minor
           requires:
             - "Prepare-mobile-workflow minor release"
@@ -111,6 +116,7 @@ workflows:
       - orb-tools/dev-promote-prod:
           name: "Publish prepare-mobile-workflow major release"
           orb-name: freeletics/prepare-mobile-workflow
+          publish-version-tag: false
           release: major
           requires:
             - "Prepare-mobile-workflow major release"
@@ -138,6 +144,7 @@ workflows:
       - orb-tools/dev-promote-prod:
           name: "Publish firebase-testlab patch release"
           orb-name: freeletics/firebase-testlab
+          publish-version-tag: false
           release: patch
           requires:
             - "Firebase-testlab patch release"
@@ -149,6 +156,7 @@ workflows:
       - orb-tools/dev-promote-prod:
           name: "Publish firebase-testlab minor release"
           orb-name: freeletics/firebase-testlab
+          publish-version-tag: false
           release: minor
           requires:
             - "Firebase-testlab minor release"
@@ -160,6 +168,60 @@ workflows:
       - orb-tools/dev-promote-prod:
           name: "Publish firebase-testlab major release"
           orb-name: freeletics/firebase-testlab
+          publish-version-tag: false
           release: major
           requires:
             - "Firebase-testlab major release"
+
+      # Kaniko Publish
+      - orb-tools/pack:
+          name: Pack kaniko-publish
+          source-dir: kaniko-publish/
+          destination-orb-path: kaniko-publish-orb.yml
+          workspace-path: kaniko-publish-orb.yml
+          artifact-path: kaniko-publish-orb.yml
+          requires:
+            - orb-tools/lint
+      - orb-tools/publish-dev:
+          name: Publish kaniko-publish dev release
+          orb-name: freeletics/kaniko-publish
+          orb-path: workspace/kaniko-publish-orb.yml
+          requires:
+            - "Pack kaniko-publish"
+      - "kaniko-publish patch release":
+          type: approval
+          requires:
+            - "Publish kaniko-publish dev release"
+          <<: *only_master_branch
+      - orb-tools/dev-promote-prod:
+          name: "Publish kaniko-publish patch release"
+          orb-name: freeletics/kaniko-publish
+          publish-version-tag: false
+          release: patch
+          requires:
+            - "kaniko-publish patch release"
+      - "kaniko-publish minor release":
+          type: approval
+          requires:
+            - "Publish kaniko-publish dev release"
+          <<: *only_master_branch
+      - orb-tools/dev-promote-prod:
+          name: "Publish kaniko-publish minor release"
+          orb-name: freeletics/kaniko-publish
+          publish-version-tag: false
+          release: minor
+          requires:
+            - "kaniko-publish minor release"
+      - "kaniko-publish major release":
+          type: approval
+          requires:
+            - "Publish kaniko-publish dev release"
+          <<: *only_master_branch
+      - orb-tools/dev-promote-prod:
+          name: "Publish kaniko-publish major release"
+          orb-name: freeletics/kaniko-publish
+          publish-version-tag: false
+          release: major
+          requires:
+            - "kaniko-publish major release"
+

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Source of Freeletics CircleCI orbs: https://circleci.com/docs/2.0/creating-orbs/
 - [freeletics/gradle-publish](gradle-publish/) - sign and publish Gradle artifacts
 - [freeletics/prepare-mobile-workflow](prepare-mobile-workflow/) - caches everything (git and dependencies) and prepares workflow for further mobile builds (Android and iOS)
 - [freeletics/firebase-testlab](firebase-testlab/) - run instrumnentation tests on Firebase TestLab
+- [freeletics/kaniko-publish](kaniko-publish/) - Build and publish container images to container registries *without* docker

--- a/kaniko-publish/Dockerfile
+++ b/kaniko-publish/Dockerfile
@@ -1,0 +1,18 @@
+# based on https://github.com/GoogleContainerTools/kaniko/blob/4feed0ff357cc224b73fc36326d4b6df6748893a/deploy/Dockerfile_debug
+
+FROM gcr.io/kaniko-project/executor:latest as builder
+
+FROM alpine
+
+COPY --from=builder /kaniko /kaniko
+RUN echo "{}" > /kaniko/.docker/config.json
+
+ENV PATH="$PATH:/kaniko" \
+    SSL_CERT_DIR=/kaniko/ssl/certs \
+    DOCKER_CONFIG /kaniko/.docker/
+
+# Declare /workspace as a volume so kaniko leaves it alone
+VOLUME /workspace
+WORKDIR /workspace
+
+ENTRYPOINT ["/kaniko/executor"]

--- a/kaniko-publish/README.md
+++ b/kaniko-publish/README.md
@@ -1,0 +1,23 @@
+# Kaniko Publish Orb
+
+Build and publish container images to container registries *without* docker
+
+Under the hood this uses Google's [Kaniko](https://github.com/GoogleContainerTools/kaniko) project, but aims to provide a very similar interface to the [circleci/docker-publish](https://circleci.com/orbs/registry/orb/circleci/docker-publish) orb.
+
+## Usage
+
+See https://github.com/freeletics/circleci_orbs/tree/master/kaniko-publish-orb for the full details.
+
+```
+orbs:
+  kaniko-publish: glenjamin/kaniko-publish@0.0.1
+
+workflows:
+  flow:
+    jobs:
+      - kaniko-publish/publish
+```
+
+## Credits
+
+Thanks to [Glenjamin](https://github.com/glenjamin/) for the amazing work on [Kaniko Publish Orb](https://github.com/glenjamin/kaniko-publish-orb/)

--- a/kaniko-publish/kaniko-publish-orb.yml
+++ b/kaniko-publish/kaniko-publish-orb.yml
@@ -1,0 +1,360 @@
+version: 2.1
+
+orbs:
+  orb-tools: circleci/orb-tools@7.3.0
+  cli: circleci/circleci-cli@0.1.2
+  docker-publish: circleci/docker-publish@0.1.4
+
+  kaniko-publish:
+    description: |
+      Build and publish container images to container registries *without* docker
+
+      Under the hood this uses Google's Kaniko project, but aims to provide a
+      very similar interface as the circleci/docker-publish orb.
+
+      See https://github.com/freeletics/circleci_orbs/tree/master/kaniko-publish-orb for the full details.
+
+      The kaniko binary is quite fussy, so I suggest you try and stick to using
+      the provided job or at least the executor. If you need to do more work
+      consider either doing it in a previous job and transferring via a workspace,
+      or build a container based on the one we're using.
+
+    examples:
+      standard_build_and_push:
+        description: |
+          A standard docker workflow, where you are building an image with a
+          Dockerfile in the root of your repository, naming the image to be the
+          same name as your repository, and then pushing to the default docker
+          registry (at docker.io).
+
+        usage:
+          version: 2.1
+          orbs:
+            kaniko-publish: freeletics/kaniko-publish@0.0.1
+
+          workflows:
+            build_and_publish_image:
+              jobs:
+                - kaniko-publish/publish
+
+      custom_name_and_tag:
+        description: Build and Deploy image with a custom name and tag.
+        usage:
+          version: 2.1
+          orbs:
+            kaniko-publish: freeletics/kaniko-publish@0.0.1
+          workflows:
+            build_and_publish_image:
+              jobs:
+                - docker-publish/publish:
+                    image: my/image
+                    tag: my_tag
+
+      custom_registry_and_dockerfile:
+        description: |
+          Build and Deploy image with a non standard Dockerfile and to a
+          custom registry.
+        usage:
+          version: 2.1
+          orbs:
+            kaniko-publish: freeletics/kaniko-publish@0.0.1
+          workflows:
+            build_and_publish_image:
+              jobs:
+                - docker-publish/publish:
+                    registry: my.docker.registry
+                    dockerfile: path/to/MyDockerFile
+
+      caching_layers:
+        description: Use the Docker Registry to cache built layers
+        usage:
+          version: 2.1
+          orbs:
+            kaniko-publish: freeletics/kaniko-publish@0.0.1
+          workflows:
+            build_and_publish_image:
+              jobs:
+                - docker-publish/publish:
+                    cache: true
+
+      life_cycle_hooks:
+        description: |
+          Build and deploy an image with custom lifecycle hooks; before
+          checking out the code from the VCS repository, before building the
+          docker image, and after building the docker image.
+        usage:
+          version: 2.1
+          orbs:
+            kaniko-publish: freeletics/kaniko-publish@0.0.1
+          workflows:
+            workflow_with_lifecycle:
+              jobs:
+                - kaniko-publish/publish:
+                    after_checkout:
+                      - run:
+                          name: Do this after checkout.
+                          command: echo "Did this after checkout"
+                    before_build:
+                      - run:
+                          name: Do this before the build.
+                          command: echo "Did this before the build"
+                    after_build:
+                      - run:
+                          name: Do this after the build.
+                          command: echo "Did this after the build"
+
+      build_without_publishing_job:
+        description: >
+          Build, but don't publish, an image using the publish job.
+
+        usage:
+          version: 2.1
+          orbs:
+            kaniko-publish: freeletics/kaniko-publish@0.0.1
+          workflows:
+            build_without_publishing:
+              jobs:
+                - kaniko-publish/publish:
+                    deploy: false
+                    tar_path: container.tar
+
+      build_without_publishing_commands:
+        description: >
+          Build, but don't publish, an image using the check and build jobs.
+
+        usage:
+          version: 2.1
+          orbs:
+            kaniko-publish: freeletics/kaniko-publish@0.0.1
+          jobs:
+            check_and_build_only:
+              executor: kaniko-publish/docker
+              steps:
+                - checkout
+                - kaniko-publish/check
+                - kaniko-publish/build_and_push:
+                    deploy: false
+
+          workflows:
+            build_without_publishing:
+              jobs:
+                - check_and_build_only
+
+      with_extra_build_args:
+        description: >
+          Build/publish an image with extra build arguments
+
+        usage:
+          version: 2.1
+          orbs:
+            kaniko-publish: freeletics/kaniko-publish@0.0.1
+          workflows:
+            extra_build_args:
+              jobs:
+                - kaniko-publish/publish:
+                    extra_build_args: --build-arg FOO=bar --build-arg BAZ=qux
+
+    executors:
+      kaniko:
+        docker:
+          - image: glenathan/circleci-kaniko:build-62
+        working_directory: /workspace
+
+    commands:
+      check:
+        description: |
+          Sanity check to make sure you can push a container image.
+
+            * check that $DOCKER_LOGIN and $DOCKER_PASSWORD environment variables are set
+            * run docker login to ensure that you can push the built image
+        parameters:
+          registry:
+            description: Name of registry to use. Defaults to docker.io.
+            type: string
+            default: docker.io
+        steps:
+          - run:
+              name: "kaniko-publish: Simulate Docker Login"
+              command: |
+                check_var() {
+                  if [[ -z "${1}" ]]; then
+                    echo "${!1@} is not set, will not be able to push image." 1>&2
+                    exit 1
+                  fi
+                }
+
+                if [ "<< parameters.registry >>" = "docker.io"]; then
+                  check_var "${DOCKER_LOGIN}"
+                  check_var "${DOCKER_PASSWORD}"
+
+                  auth=$(printf "${DOCKER_LOGIN}:${DOCKER_PASSWORD}" | base64)
+                  cat \<< JSON > /kaniko/.docker/config.json
+                  {
+                    "auths": {
+                      "https://index.docker.io/v1/": {
+                        "auth": "${auth}"
+                      }
+                    }
+                  }
+                  JSON
+                elif [[ "<< parameters.registry >>" ~= "*." =~ [0-9]+\.dkr\.ecr\..*\.amazonaws\.com ]]; then
+                  check_var "${AWS_ACCESS_KEY_ID}"
+                  check_var "${AWS_SECRET_ACCESS_KEY}"
+
+                  echo '{ "credsStore": "ecr-login" }' > /kaniko/.docker/config.json
+                else
+                  cat \<< EOF
+                    Docker Registry not yet supported, please fill an issue/feature request on GitHub or send a PR.
+
+                    Alternatively, you can disable this setting the check to false,
+                      and use the before_build parameter to configure your registry properly.
+                  EOF
+                  exit 1
+                fi
+
+      build_and_push:
+        description: Builds, tags and pushes a container image
+        parameters:
+          dockerfile:
+            description: Name of dockerfile to use. Defaults to Dockerfile.
+            type: string
+            default: Dockerfile
+          path:
+            description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
+            type: string
+            default: $(pwd)
+          image:
+            description: Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
+            type: string
+            default: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
+          tag:
+            description: Value for tag to use. Defaults to $CIRCLE_SHA1.
+            type: string
+            default: $CIRCLE_SHA1
+          cache:
+            description: Whether or not to cache layers of the Docker image being built
+            type: boolean
+            default: false
+          registry:
+            description: Name of registry to use. Defaults to docker.io.
+            type: string
+            default: docker.io
+          extra_build_args:
+            description: >
+              Extra flags to pass to kaniko/executor. For examples, see
+              https://github.com/GoogleContainerTools/kaniko#additional-flags
+            type: string
+            default: ""
+          deploy:
+            description: Whether or not to push image to a registry.
+            type: boolean
+            default: true
+          tar_path:
+            description: Set this if you want to produce a container tarball when not deploying
+            type: string
+            default: ""
+        steps:
+          - run:
+              name: "kaniko-publish: build and push container"
+              shell: /bin/sh -uxeo pipefail
+              command: >-
+                /kaniko/executor
+                --dockerfile "<< parameters.dockerfile >>"
+                --context "<< parameters.path >>"
+                --destination "<< parameters.registry >>/<< parameters.image >>:<< parameters.tag >>"
+                --cache << parameters.cache >>
+                <<^parameters.deploy>>
+                --no-push
+                <</parameters.deploy>>
+                <<#parameters.tar_path>>
+                --tarPath "<< parameters.tar_path >>"
+                <</parameters.tar_path>>
+                << parameters.extra_build_args >>
+
+    jobs:
+      publish:
+        executor: kaniko
+        parameters:
+          dockerfile:
+            description: Name of dockerfile to use. Defaults to Dockerfile.
+            type: string
+            default: Dockerfile
+          path:
+            description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
+            type: string
+            default: $(pwd)
+          image:
+            description: Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
+            type: string
+            default: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
+          tag:
+            description: Value for tag to use. Defaults to $CIRCLE_SHA1.
+            type: string
+            default: $CIRCLE_SHA1
+          registry:
+            description: Name of registry to use. Defaults to docker.io.
+            type: string
+            default: docker.io
+          extra_build_args:
+            description: >
+              Extra flags to pass to kaniko/executor. For examples, see
+              https://github.com/GoogleContainerTools/kaniko#additional-flags
+            type: string
+            default: ""
+          after_checkout:
+            description: Optional steps to run after checking out the code.
+            type: steps
+            default: []
+          before_build:
+            description: Optional steps to run before building the docker image.
+            type: steps
+            default: []
+          after_build:
+            description: Optional steps to run after building the docker image.
+            type: steps
+            default: []
+          check:
+            description: Whether or not to run the check for Docker registry variables and configuration
+            type: boolean
+            default: true
+          cache:
+            description: Whether or not to cache layers of the Docker image being built
+            type: boolean
+            default: false
+          deploy:
+            description: Whether or not to push image to a registry.
+            type: boolean
+            default: true
+          tar_path:
+            description: Set this if you want to produce a container tarball when not deploying
+            type: string
+            default: ""
+        steps:
+          - checkout
+          - when:
+              name: Run after_checkout lifecycle hook steps.
+              condition: << parameters.after_checkout >>
+              steps: << parameters.after_checkout >>
+          - when:
+              condition: <<parameters.check>>
+              steps:
+                - check:
+                    registry: << parameters.registry >>
+          - when:
+              name: Run before_build lifecycle hook steps.
+              condition: << parameters.before_build >>
+              steps: << parameters.before_build >>
+          - build_and_push:
+              dockerfile: << parameters.dockerfile >>
+              path: << parameters.path >>
+              image: << parameters.image >>
+              tag: << parameters.tag >>
+              cache: << parameters.cache >>
+              registry: << parameters.registry >>
+              extra_build_args: << parameters.extra_build_args >>
+              deploy: << parameters.deploy >>
+              tar_path: << parameters.tar_path >>
+          - when:
+              name: Run after_build lifecycle hook steps.
+              condition: << parameters.after_build >>
+              steps: << parameters.after_build >>


### PR DESCRIPTION
Most of the code came from
https://github.com/glenjamin/kaniko-publish-orb/ with some additions for
AWS ECR support.

Including kaniko-publish orb to the mix and including the parameter to not publish tags on orb-tools