### PR TITLE
Fixing the Kaniko Check step

### DIFF
--- a/kaniko-publish/Dockerfile
+++ b/kaniko-publish/Dockerfile
@@ -1,15 +1,14 @@
-# based on https://github.com/GoogleContainerTools/kaniko/blob/4feed0ff357cc224b73fc36326d4b6df6748893a/deploy/Dockerfile_debug
+# Ref: https://github.com/GoogleContainerTools/kaniko/blob/4feed0ff357cc224b73fc36326d4b6df6748893a/deploy/Dockerfile_debug
+FROM gcr.io/kaniko-project/executor:v0.17.1 as builder
 
-FROM gcr.io/kaniko-project/executor:latest as builder
-
-FROM alpine
+FROM debian:10.3-slim
 
 COPY --from=builder /kaniko /kaniko
 RUN echo "{}" > /kaniko/.docker/config.json
 
 ENV PATH="$PATH:/kaniko" \
     SSL_CERT_DIR=/kaniko/ssl/certs \
-    DOCKER_CONFIG /kaniko/.docker/
+    DOCKER_CONFIG=/kaniko/.docker/
 
 # Declare /workspace as a volume so kaniko leaves it alone
 VOLUME /workspace

--- a/kaniko-publish/commands/build-and-push.yml
+++ b/kaniko-publish/commands/build-and-push.yml
@@ -7,7 +7,7 @@ parameters:
   path:
     description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
     type: string
-    default: $(pwd)
+    default: $CIRCLE_WORKING_DIRECTORY
   image:
     description: Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
     type: string

--- a/kaniko-publish/commands/check.yml
+++ b/kaniko-publish/commands/check.yml
@@ -13,37 +13,35 @@ steps:
       command: |
         check_var() {
           if [[ -z "${1}" ]]; then
-            echo "${!1@} is not set, will not be able to push image." 1>&2
+            echo "Variables aren't properly set, will not be able to push image." 1>&2
             exit 1
           fi
         }
 
-        if [ "<< parameters.image_repository >>" =~ "docker.io\/.*"]; then
+        # if [[ "<< parameters.image_repository >>" =~ "docker.io\/.*" ]]; then
+        if [[ $(echo "<< parameters.image_repository >>" | grep -w docker.io) ]]; then
           check_var "${DOCKER_LOGIN}"
           check_var "${DOCKER_PASSWORD}"
 
           auth=$(printf "${DOCKER_LOGIN}:${DOCKER_PASSWORD}" | base64)
-          cat \<< JSON > /kaniko/.docker/config.json
-          {
+          echo '{
             "auths": {
               "https://index.docker.io/v1/": {
-                "auth": "${auth}"
+                "auth": "'${auth}'"
               }
             }
-          }
-          JSON
-        elif [[ "<< parameters.image_repository >>" =~ [0-9]+\.dkr\.ecr\..*\.amazonaws\.com\/.* ]]; then
+          }' >/kaniko/.docker/config.json
+        elif [[ $(echo "<< parameters.image_repository >>" | grep -w amazonaws.com) ]]; then
           check_var "${AWS_ACCESS_KEY_ID}"
           check_var "${AWS_SECRET_ACCESS_KEY}"
 
           echo '{ "credsStore": "ecr-login" }' > /kaniko/.docker/config.json
         else
-          cat \<< EOF
+          echo "
             Docker Registry not yet supported for check command
             Please fill an issue/feature request on GitHub or send a PR.
 
             Alternatively, you can disable this setting the check to false,
-              and use the before_build parameter to configure your registry properly.
-          EOF
+              and use the before_build parameter to configure your registry properly."
           exit 1
         fi

--- a/kaniko-publish/executors/kaniko.yml
+++ b/kaniko-publish/executors/kaniko.yml
@@ -6,11 +6,11 @@ parameters:
   image_repository:
     description: Docker image tag to pull for execution
     type: string
-    default: glenathan/circleci-kaniko
+    default: freeletics/kaniko-executor
   image_tag:
     description: Image tag to pull for execution
     type: string
-    default: build-62
+    default: latest
 resource_class: small
 working_directory: << parameters.working_directory >>
 docker:

--- a/kaniko-publish/jobs/publish.yml
+++ b/kaniko-publish/jobs/publish.yml
@@ -7,7 +7,7 @@ parameters:
   path:
     description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
     type: string
-    default: $(pwd)
+    default: $CIRCLE_WORKING_DIRECTORY
   image:
     description: Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
     type: string


### PR DESCRIPTION
Some syntax issues and errors with cat along the way

Dockerfile included, number of layers reduced, base image version pinned
and changed from alpine to debian (CircleCI is having issues with some
libraries from Alpine trying to use busybox)