### PR TITLE
Increase executor to large for 'prepare-mobile-workflow' job.

### DIFF
--- a/mobile-shared-executors/android-large.yml
+++ b/mobile-shared-executors/android-large.yml
@@ -5,6 +5,9 @@ parameters:
   working_directory:
     type: string
     default: /home/circleci/repo
+  gradle_user_home:
+    type: string
+    default: /home/circleci/.gradle
 resource_class: large
 docker:
   - image: freeletics/android-sdk:<< parameters.tag >>
@@ -13,3 +16,4 @@ environment:
   TERM: dumb
   JAVA_TOOL_OPTIONS: "-Xmx5g -XX:MaxMetaspaceSize=1g -XX:MaxRAMFraction=2"
   MAX_WORKERS: "4"
+  GRADLE_USER_HOME: << parameters.gradle_user_home >>

--- a/prepare-mobile-workflow/jobs/prepare-android-workflow.yml
+++ b/prepare-mobile-workflow/jobs/prepare-android-workflow.yml
@@ -39,7 +39,7 @@ parameters:
     default: /home/circleci/repo
 
 executor:
-  name: android-medium
+  name: android-large
   gradle_user_home: << parameters.gradle_user_home >>
   working_directory: << parameters.working_directory >>
 


### PR DESCRIPTION
Recently Gradle dependencies sync started to use a lot of memory.