### PR TITLE
Update 'prepare-mobile-workflow' android executors to support CircleCI limits.

### DIFF
--- a/mobile-shared-executors/android-large.yml
+++ b/mobile-shared-executors/android-large.yml
@@ -14,6 +14,5 @@ docker:
 working_directory: << parameters.working_directory >>
 environment:
   TERM: dumb
-  JAVA_TOOL_OPTIONS: "-Xmx5g -XX:MaxMetaspaceSize=1g -XX:MaxRAMFraction=2"
-  MAX_WORKERS: "4"
+  JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:-PreferContainerQuotaForCPUCount"
   GRADLE_USER_HOME: << parameters.gradle_user_home >>

--- a/mobile-shared-executors/android-medium-plus.yml
+++ b/mobile-shared-executors/android-medium-plus.yml
@@ -5,11 +5,14 @@ parameters:
   working_directory:
     type: string
     default: /home/circleci/repo
+  gradle_user_home:
+    type: string
+    default: /home/circleci/.gradle
 resource_class: medium+
 docker:
   - image: freeletics/android-sdk:<< parameters.tag >>
 working_directory: << parameters.working_directory >>
 environment:
   TERM: dumb
-  JAVA_TOOL_OPTIONS: "-Xmx3g -XX:MaxMetaspaceSize=1g -XX:MaxRAMFraction=2"
-  MAX_WORKERS: "3"
+  JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:-PreferContainerQuotaForCPUCount"
+  GRADLE_USER_HOME: << parameters.gradle_user_home >>

--- a/mobile-shared-executors/android-medium.yml
+++ b/mobile-shared-executors/android-medium.yml
@@ -14,6 +14,5 @@ docker:
 working_directory: << parameters.working_directory >>
 environment:
   TERM: dumb
-  JAVA_TOOL_OPTIONS: "-Xmx2g -XX:MaxMetaspaceSize=512m -XX:MaxRAMFraction=2"
-  MAX_WORKERS: "2"
+  JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:-PreferContainerQuotaForCPUCount"
   GRADLE_USER_HOME: << parameters.gradle_user_home >>

--- a/mobile-shared-executors/android-small.yml
+++ b/mobile-shared-executors/android-small.yml
@@ -5,11 +5,14 @@ parameters:
   working_directory:
     type: string
     default: /home/circleci/repo
+  gradle_user_home:
+    type: string
+    default: /home/circleci/.gradle
 resource_class: small
 docker:
   - image: freeletics/android-sdk:<< parameters.tag >>
 working_directory: << parameters.working_directory >>
 environment:
   TERM: dumb
-  JAVA_TOOL_OPTIONS: "-Xmx1g -XX:MaxMetaspaceSize=256m -XX:MaxRAMFraction=2"
-  MAX_WORKERS: "1"
+  JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:-PreferContainerQuotaForCPUCount"
+  GRADLE_USER_HOME: << parameters.gradle_user_home >>

--- a/mobile-shared-executors/android-xlarge.yml
+++ b/mobile-shared-executors/android-xlarge.yml
@@ -5,11 +5,14 @@ parameters:
   working_directory:
     type: string
     default: /home/circleci/repo
+  gradle_user_home:
+    type: string
+    default: /home/circleci/.gradle
 resource_class: xlarge
 docker:
   - image: freeletics/android-sdk:<< parameters.tag >>
 working_directory: << parameters.working_directory >>
 environment:
   TERM: dumb
-  JAVA_TOOL_OPTIONS: "-Xmx11g -XX:MaxMetaspaceSize=1g -XX:MaxRAMFraction=2"
-  MAX_WORKERS: "8"
+  JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:-PreferContainerQuotaForCPUCount"
+  GRADLE_USER_HOME: << parameters.gradle_user_home >>

--- a/mobile-shared-executors/fastlane-android-large.yml
+++ b/mobile-shared-executors/fastlane-android-large.yml
@@ -5,12 +5,15 @@ parameters:
   working_directory:
     type: string
     default: /home/circleci/home
+  gradle_user_home:
+    type: string
+    default: /home/circleci/.gradle
 resource_class: large
 docker:
   - image: freeletics/android-sdk-fastlane:<< parameters.tag >>
 working_directory: << parameters.working_directory >>
 environment:
   TERM: dumb
-  JAVA_TOOL_OPTIONS: "-Xmx5g -XX:MaxMetaspaceSize=1g -XX:MaxRAMFraction=2"
-  MAX_WORKERS: "4"
   FASTLANE_SKIP_UPDATE_CHECK: true
+  JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:-PreferContainerQuotaForCPUCount"
+  GRADLE_USER_HOME: << parameters.gradle_user_home >>

--- a/mobile-shared-executors/fastlane-android-small.yml
+++ b/mobile-shared-executors/fastlane-android-small.yml
@@ -5,12 +5,15 @@ parameters:
   working_directory:
     type: string
     default: /home/circleci/repo
+  gradle_user_home:
+    type: string
+    default: /home/circleci/.gradle
 resource_class: small
 docker:
   - image: freeletics/android-sdk-fastlane:<< parameters.tag >>
 working_directory: << parameters.working_directory >>
 environment:
   TERM: dumb
-  JAVA_TOOL_OPTIONS: "-Xmx1g -XX:MaxMetaspaceSize=256m -XX:MaxRAMFraction=2"
-  MAX_WORKERS: "1"
   FASTLANE_SKIP_UPDATE_CHECK: true
+  JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:-PreferContainerQuotaForCPUCount"
+  GRADLE_USER_HOME: << parameters.gradle_user_home >>

--- a/prepare-mobile-workflow/jobs/prepare-android-workflow.yml
+++ b/prepare-mobile-workflow/jobs/prepare-android-workflow.yml
@@ -39,7 +39,7 @@ parameters:
     default: /home/circleci/repo
 
 executor:
-  name: android-large
+  name: android-medium-plus
   gradle_user_home: << parameters.gradle_user_home >>
   working_directory: << parameters.working_directory >>
 


### PR DESCRIPTION
Now executors will use container limits for JVM processes and allow to override gradle home location.

Part of https://freeletics.atlassian.net/browse/PE-19872