### PR TITLE
make prepare-android-workflow take the executor as parameter

### DIFF
--- a/prepare-mobile-workflow/jobs/prepare-android-workflow.yml
+++ b/prepare-mobile-workflow/jobs/prepare-android-workflow.yml
@@ -34,12 +34,11 @@ parameters:
     description: "The executor to run this job on."
     type: executor
   gradle_user_home:
-    description: "Path to Gradle user home directory."
+    description: "Path to Gradle user home directory. Make sure this matches the executor."
     type: string
     default: "~/.gradle"
 
 executor: << parameters.executor >>
-  gradle_user_home: << parameters.gradle_user_home >>
 
 steps:
   - checkout-from-git-cache:

--- a/prepare-mobile-workflow/jobs/prepare-android-workflow.yml
+++ b/prepare-mobile-workflow/jobs/prepare-android-workflow.yml
@@ -30,18 +30,16 @@ parameters:
     description: "Optional steps to perform after checkout, but before saving to workspace."
     type: steps
     default: []
+  executor:
+    description: "The executor to run this job on."
+    type: executor
   gradle_user_home:
     description: "Path to Gradle user home directory."
     type: string
     default: "~/.gradle"
-  working_directory:
-    type: string
-    default: /home/circleci/repo
 
-executor:
-  name: android-medium-plus
+executor: << parameters.executor >>
   gradle_user_home: << parameters.gradle_user_home >>
-  working_directory: << parameters.working_directory >>
 
 steps:
   - checkout-from-git-cache:


### PR DESCRIPTION
`gradle_user_home` needed to stay because it's used for caching.