### PR TITLE
Android images: Command line tools 3.0 and OpenJDK 11

### DIFF
--- a/mobile-shared-executors/android-large.yml
+++ b/mobile-shared-executors/android-large.yml
@@ -1,7 +1,7 @@
 parameters:
   tag:
     type: string
-    default: "1.4"
+    default: "1.5"
   working_directory:
     type: string
     default: /home/circleci/repo

--- a/mobile-shared-executors/android-medium-plus.yml
+++ b/mobile-shared-executors/android-medium-plus.yml
@@ -1,7 +1,7 @@
 parameters:
   tag:
     type: string
-    default: "1.4"
+    default: "1.5"
   working_directory:
     type: string
     default: /home/circleci/repo

--- a/mobile-shared-executors/android-medium.yml
+++ b/mobile-shared-executors/android-medium.yml
@@ -1,7 +1,7 @@
 parameters:
   tag:
     type: string
-    default: "1.4"
+    default: "1.5"
   working_directory:
     type: string
     default: /home/circleci/repo

--- a/mobile-shared-executors/android-small.yml
+++ b/mobile-shared-executors/android-small.yml
@@ -1,7 +1,7 @@
 parameters:
   tag:
     type: string
-    default: "1.4"
+    default: "1.5"
   working_directory:
     type: string
     default: /home/circleci/repo

--- a/mobile-shared-executors/android-xlarge.yml
+++ b/mobile-shared-executors/android-xlarge.yml
@@ -1,7 +1,7 @@
 parameters:
   tag:
     type: string
-    default: "1.4"
+    default: "1.5"
   working_directory:
     type: string
     default: /home/circleci/repo

--- a/mobile-shared-executors/docker/android-sdk-fastlane/Dockerfile
+++ b/mobile-shared-executors/docker/android-sdk-fastlane/Dockerfile
@@ -1,4 +1,4 @@
-FROM freeletics/android-sdk:1.4
+FROM freeletics/android-sdk:1.5
 
 # Adding Android bundletool
 COPY files/bundletool-all-0.11.0.jar /usr/bin/bundletool.jar

--- a/mobile-shared-executors/docker/android-sdk/Dockerfile
+++ b/mobile-shared-executors/docker/android-sdk/Dockerfile
@@ -17,7 +17,7 @@ ARG CMDLINE_TOOLS_REVISION=6858069_latest # 3.0
 ARG sdk_file=commandlinetools-linux-${CMDLINE_TOOLS_REVISION}.zip
 RUN wget -q -O /tmp/${sdk_file} https://dl.google.com/android/repository/${sdk_file}
 RUN unzip -qo /tmp/${sdk_file} -d ${android_home}/cmdline-tools
-RUN mv ${android_home}/cmdline-tools/cmdline-tools ${android_home}/cmdline-tools/lates
+RUN mv ${android_home}/cmdline-tools/cmdline-tools ${android_home}/cmdline-tools/latest
 
 # Second build stage
 # - OpenJDK + Android SDK
@@ -61,5 +61,5 @@ COPY --chown=circleci:circleci --from=android-sdk-tools /android-sdk ${android_h
 
 # Set environmental variables
 ENV ANDROID_HOME ${android_home}
-ENV PATH=${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${PATH}
+ENV PATH=${ANDROID_HOME}/emulator:${ANDROID_HOME}/cmdline-tools/latest:${ANDROID_HOME}/platform-tools:${PATH}
 ENV TERM dumb

--- a/mobile-shared-executors/docker/android-sdk/Dockerfile
+++ b/mobile-shared-executors/docker/android-sdk/Dockerfile
@@ -22,7 +22,7 @@ RUN mv ${android_home}/cmdline-tools/cmdline-tools ${android_home}/cmdline-tools
 # Second build stage
 # - OpenJDK + Android SDK
 # - some utilities
-FROM openjdk:8u252
+FROM openjdk:11.0.9.1-jdk
 
 RUN apt-get update \
   && apt-get install -y \

--- a/mobile-shared-executors/docker/android-sdk/Dockerfile
+++ b/mobile-shared-executors/docker/android-sdk/Dockerfile
@@ -5,21 +5,19 @@ FROM alpine:3.11.6 as android-sdk-tools
 
 # Android SDK location
 ARG android_home=/android-sdk
-RUN mkdir -p ${android_home}
+RUN mkdir -p ${android_home}/cmdline-tools
+RUN mkdir -p ${android_home}/licenses
 
 # Accept Android SDK licenses
-RUN mkdir -p ${android_home}/licenses
-ARG sdk_license="d56f5187479451eabf01fb78af6dfcb131a6481e\n24333f8a63b6825ea9c5514f83c2829b004d1fee\n"
-RUN echo -e ${sdk_license} > "${android_home}/licenses/android-sdk-license"
-ARG sdk_license_preview="84831b9409646a918e30573bab4c9c91346d8abd\n"
-RUN echo -e ${sdk_license_preview} > "${android_home}/licenses/android-sdk-preview-license"
+RUN echo -e "24333f8a63b6825ea9c5514f83c2829b004d1fee\n" > "${android_home}/licenses/android-sdk-license"
+RUN echo -e "84831b9409646a918e30573bab4c9c91346d8abd\n" > "${android_home}/licenses/android-sdk-preview-license"
 
 # Download and install Android SDK
-ARG SDK_TOOLS_REVISION=6514223_latest
-ARG sdk_file=commandlinetools-linux-${SDK_TOOLS_REVISION}.zip
-RUN wget -q -O /tmp/${sdk_file} https://dl.google.com/android/repository/commandlinetools-linux-${SDK_TOOLS_REVISION}.zip
-RUN unzip -q /tmp/${sdk_file} -d ${android_home}
-
+ARG CMDLINE_TOOLS_REVISION=6858069_latest # 3.0
+ARG sdk_file=commandlinetools-linux-${CMDLINE_TOOLS_REVISION}.zip
+RUN wget -q -O /tmp/${sdk_file} https://dl.google.com/android/repository/${sdk_file}
+RUN unzip -qo /tmp/${sdk_file} -d ${android_home}/cmdline-tools
+RUN mv ${android_home}/cmdline-tools/cmdline-tools ${android_home}/cmdline-tools/lates
 
 # Second build stage
 # - OpenJDK + Android SDK

--- a/mobile-shared-executors/docker/android-sdk/README.md
+++ b/mobile-shared-executors/docker/android-sdk/README.md
@@ -5,7 +5,7 @@ Hosted at https://hub.docker.com/r/freeletics/android-sdk/
 ## Contents
 
 * OpenJDK 8
-* Android SDK command line tools 1.0.0
+* Android SDK command line tools 3.0
 * Android SDK license
 * Android SDK preview license
 * `ANDROID_HOME` env var is set

--- a/mobile-shared-executors/fastlane-android-large.yml
+++ b/mobile-shared-executors/fastlane-android-large.yml
@@ -1,7 +1,7 @@
 parameters:
   tag:
     type: string
-    default: "1.7"
+    default: "1.8"
   working_directory:
     type: string
     default: /home/circleci/repo

--- a/mobile-shared-executors/fastlane-android-small.yml
+++ b/mobile-shared-executors/fastlane-android-small.yml
@@ -1,7 +1,7 @@
 parameters:
   tag:
     type: string
-    default: "1.7"
+    default: "1.8"
   working_directory:
     type: string
     default: /home/circleci/repo


### PR DESCRIPTION
- update command line tools to version 3.0
- ensure proper directory structure for command line tools `/cmdline-tools/latest`, otherwise it will fail because relative paths don't work
- update PATH env var to use command line tools instead of old tools
- update base images to JDK 11

These images are already published as 1.5 and 1.8 respectively.