### PR TITLE
update Fastlane to 2.172.0

### DIFF
--- a/mobile-shared-executors/docker/android-sdk-fastlane/files/Gemfile
+++ b/mobile-shared-executors/docker/android-sdk-fastlane/files/Gemfile
@@ -1,9 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'fastlane', '2.136.0'
+gem 'fastlane', '2.172.0'
 gem 'jira-ruby', '1.7.0'
 gem 'chunky_png', '1.3.11'
 gem 'rqrcode', '0.10.1'
 gem 'aws-sdk', '3.0.1'
 gem 'fileutils', '1.2.0'
-

--- a/mobile-shared-executors/fastlane-android-large.yml
+++ b/mobile-shared-executors/fastlane-android-large.yml
@@ -1,7 +1,7 @@
 parameters:
   tag:
     type: string
-    default: "1.8"
+    default: "1.9"
   working_directory:
     type: string
     default: /home/circleci/repo

--- a/mobile-shared-executors/fastlane-android-small.yml
+++ b/mobile-shared-executors/fastlane-android-small.yml
@@ -1,7 +1,7 @@
 parameters:
   tag:
     type: string
-    default: "1.8"
+    default: "1.9"
   working_directory:
     type: string
     default: /home/circleci/repo


### PR DESCRIPTION
Update the fastlane version used in our docker image. The `google_play_track_release_names` action I used was only added in a newer version than the one that we were using. https://app.circleci.com/pipelines/github/freeletics/fl-application-android/27509/workflows/f5f6ab86-825e-471a-b13f-707bbe1f3cc2/jobs/430231