### PR TITLE
Let the iOS orbs have more default values and update to the latest versions

### DIFF
--- a/prepare-mobile-workflow/commands/prepare-ios-job.yml
+++ b/prepare-mobile-workflow/commands/prepare-ios-job.yml
@@ -1,29 +1,33 @@
 description: |
-  Prepares ios job later in a workflow: attaches workspace, restore caches.
-  Assumes executor already exposes BUNDLER_VERSION and BUNDLE_PATH env variables
+  Prepares single job in a iOS workflow: attaches workspace, restore caches.
 
 parameters:
   native_extensions_cache_version:
     description: "Cache key (example \"v2\"). Could be used to invalidate cache."
     type: string
+    default: "v7"
   native-platform:
     description: |
       Ruby Native platform. For example, linux 64bit will be "x86_64-linux".
       To get your current platform, execute "bundle platform"
     type: string
+    default: universal-darwin-19
   native_extensions_cache_modifier:
     description: "Optional cache modifier. Useful to create several caches for the same dependencies file."
     type: string
-    default: ""
+    default: "ios"
   gemlock_file:
     description: "Path to the Gemfile.lock file that defines all gems and their versions."
     type: string
+    default: "Gemfile.lock"
   bundler_path:
-    description: "Path to the bundler gems installation directory."
+    description: "Path to store installed gems, default to 'vendor/bundle/<ruby-version>'"
     type: string
+    default: vendor/bundle/2.7
   bundler_version:
     description: "Bundler version to install."
     type: string
+    default: "2.2.8"
 
 steps:
   - attach_workspace:
@@ -31,9 +35,8 @@ steps:
   - run:
       name: Install bundler
       command: |
-        echo 'PATH="$(ruby -e '\''puts Gem.user_dir'\'')/bin:$PATH"' >> $BASH_ENV
-        source $BASH_ENV
         gem install --user-install bundler --version << parameters.bundler_version >>
+        bundle config path << parameters.bundler_path >>
   - sync-gems-native-extensions:
       cache_version: << parameters.native_extensions_cache_version >>
       native-platform: << parameters.native-platform >>

--- a/prepare-mobile-workflow/jobs/prepare-ios-workflow.yml
+++ b/prepare-mobile-workflow/jobs/prepare-ios-workflow.yml
@@ -4,20 +4,21 @@ description: |
 
 parameters:
   git_cache_version:
-    description: "Git cache key (example \"v2\"). Could be used to invalidate cache."
+    description: "Git cache key (example \"v6\"). Could be used to invalidate cache."
     type: string
-    default: "v2"
+    default: "v6"
   gem_cache_version:
-    description: "Gem cache key (example \"v2\"). Could be used to invalidate cache."
+    description: "Gem cache key (example \"v14\"). Could be used to invalidate cache."
     type: string
-    default: "v3"
+    default: "v14"
   cache_modifier:
     description: "Optional caches modifier. Useful to create several caches for the same dependencies file."
     type: string
-    default: ""
+    default: "ios"
   gemlock_file:
     description: "Path to the Gemfile.lock file that defines all gem dependencies and their versions."
     type: string
+    default: "Gemfile.lock"
   sync_dependencies:
     description: "Steps to sync gem dependencies."
     type: steps
@@ -29,15 +30,15 @@ parameters:
   ruby_version:
     description: "Version of ruby to use."
     type: string
-    default: "2.6"
+    default: "2.7.0"
   bundler_path:
     description: "Path to store installed gems, default to 'vendor/bundle/<ruby-version>'"
     type: string
-    default: vendor/bundle/2.6
+    default: vendor/bundle/2.7
   bundler_version:
-    description: "Bundler version to use."
+    description: "Bundler version to install."
     type: string
-    default: "2.0.2"
+    default: "2.2.8"
   working_directory:
     type: string
     default: /home/circleci/repo
@@ -63,9 +64,8 @@ steps:
   - run:
       name: Install bundler
       command: |
-            echo 'PATH="$(ruby -e '\''puts Gem.user_dir'\'')/bin:$PATH"' >> $BASH_ENV
-            source $BASH_ENV
-            gem install --user-install bundler --version $BUNDLER_VERSION
+            gem install --user-install bundler --version << parameters.bundler_version >>
+            bundle config path << parameters.bundler_path >>
   - steps: << parameters.sync_dependencies >>
   - save-gems-cache:
       cache_version: << parameters.gem_cache_version >>

--- a/prepare-mobile-workflow/prepare-mobile-workflow.yml
+++ b/prepare-mobile-workflow/prepare-mobile-workflow.yml
@@ -1,5 +1,5 @@
 version: 2.1
 
 description: |
-  Provides common commands/jobs that does fast git checkout, persist project to workflow,
-  populate mobile dependencies caches if dependencies has been changed.
+  Provides common commands/jobs that provide fast git checkout, persist project to workflow and
+  populate mobile dependencies caches if dependencies have changed.


### PR DESCRIPTION
Let the iOS orbs have more default values and update to the latest versions of tools.
A follow up PR in the ios repo will then remove the parameters from the call site.

Also hopefully fixed this:

<img width="1488" alt="Screenshot 2021-02-25 at 11 34 09" src="https://user-images.githubusercontent.com/5389635/109141035-8ca1a600-775d-11eb-86a0-b18a30abdd61.png">
