### PR TITLE
add FASTLANE_SKIP_UPDATE_CHECK directly to docker image

### DIFF
--- a/mobile-shared-executors/docker/android-sdk-fastlane/Dockerfile
+++ b/mobile-shared-executors/docker/android-sdk-fastlane/Dockerfile
@@ -21,3 +21,5 @@ ADD files/Gemfile Gemfile
 RUN sudo gem install -g Gemfile && \
     sudo gem cleanup && \
     sudo rm -rf /usr/lib/ruby/gems/*/cache/*
+
+ENV FASTLANE_SKIP_UPDATE_CHECK true


### PR DESCRIPTION
Right now this is defined in the secrets of the Android project, it makes more sense to just have it baked into the image.