### PR TITLE
Remove deleted branches/references from git cache

### DIFF
--- a/prepare-mobile-workflow/commands/update-git-cache.yml
+++ b/prepare-mobile-workflow/commands/update-git-cache.yml
@@ -13,7 +13,7 @@ steps:
   # remove remote branches that don't exist anymore in remote
   - run:
       name: "Prune remote branches"
-      command: git fetch --prune 
+      command: git fetch --prune
   # remove unreachable objects from git
   - run:
       name: "Prune remote branches"

--- a/prepare-mobile-workflow/commands/update-git-cache.yml
+++ b/prepare-mobile-workflow/commands/update-git-cache.yml
@@ -10,6 +10,14 @@ parameters:
 steps:
   - checkout-from-git-cache:
       cache_version: << parameters.cache_version >>
+  # remove remote branches that don't exist anymore in remote
+  - run:
+      name: "Prune remote branches"
+      command: git fetch --prune 
+  # remove unreachable objects from git
+  - run:
+      name: "Prune remote branches"
+      command: git fetch --prune
   - save_cache:
       key: << parameters.cache_version >>-git-cache-master-{{ .Revision }}
       paths:

--- a/prepare-mobile-workflow/commands/update-git-cache.yml
+++ b/prepare-mobile-workflow/commands/update-git-cache.yml
@@ -16,8 +16,8 @@ steps:
       command: git fetch --prune
   # remove unreachable objects from git
   - run:
-      name: "Prune remote branches"
-      command: git fetch --prune
+      name: "Remove unreachable git objects"
+      command: git gc
   - save_cache:
       key: << parameters.cache_version >>-git-cache-master-{{ .Revision }}
       paths:


### PR DESCRIPTION
When I created a branch called `ci` in the Android repo the checkout on ci failed like this: 
```
error: cannot lock ref 'refs/remotes/origin/ci': 'refs/remotes/origin/ci/hotfix-pipeline' exists; cannot create 'refs/remotes/origin/ci'
From github.com:freeletics/fl-application-android
 ! [new branch]            ci         -> origin/ci  (unable to update local ref)

exit status 1
```
https://app.circleci.com/pipelines/github/freeletics/fl-application-android/29374/workflows/0fd6cb80-2a0b-4a59-8e43-1c093febbd10/jobs/457497


However we don't have a branch called `ci/hotfix-pipeline` anymore. Since our `update-git-cache` job just calls `checkout-from-git-cache` we just restore the cache and then run CircleCI's `checkout. That only does a regular fetch. That means that our cache always contains all remote branches that existed at the time of each checkout, only adding to it never removing any.

This adds `git fetch --prune` which will remove all local references to remote branches that were deleted. In the best case scenario this should make the cache a lot smaller.

I've also added `git gc` to run other cleanup tasks, I'm not sure this is really needed but it's worth it to try it out imo. If we see it doesn't do anything, we can still remove it again