### PR TITLE
use git remote prune instead of fetch

### DIFF
--- a/prepare-mobile-workflow/commands/update-git-cache.yml
+++ b/prepare-mobile-workflow/commands/update-git-cache.yml
@@ -13,7 +13,7 @@ steps:
   # remove remote branches that don't exist anymore in remote
   - run:
       name: "Prune remote branches"
-      command: git fetch --prune
+      command: git remote prune origin
   # remove unreachable objects from git
   - run:
       name: "Remove unreachable git objects"


### PR DESCRIPTION
This will only delete remote branches that don't exist anymore instead of also creating new ones that the local clone didn't know about yet.