### PR TITLE
use workspaces to share test apk with firebase test lab job

### DIFF
--- a/firebase-testlab/jobs/run-android-tests.yml
+++ b/firebase-testlab/jobs/run-android-tests.yml
@@ -29,18 +29,14 @@ parameters:
     description: |
       Path to assembled android tests apk relative to working directory.
     type: string
-  add_test_configuration:
-    description: |
-      Steps to add apks and flank configuration to this job.
-      Prefer building apks themselves in a previous jobs.
-    type: steps
 
 executor:
   name: firebase-testlab
   working_directory: << parameters.working_directory >>
 
 steps:
-  - steps: << parameters.add_test_configuration >>
+  - attach_workspace:
+      root: .
   - run:
       name: Integration Tests
       no_output_timeout: << parameters.job_no_output_timeout >>


### PR DESCRIPTION
Currently we are saving built test apks into a cache and then restore that cache in the `run-android-tests` job to get them back. However CircleCI has workspaces for that and caches are meant to share data between workflows: https://circleci.com/blog/persisting-data-in-workflows-when-to-use-caching-artifacts-and-workspaces/ We already use workspaces for other things and it simplifies things to also start using them here.

The job now simply does `attach_workspace` instead of having a `add_test_configuration` parameter where we previously passed in a restore_cache step (see pr in android repo https://github.com/freeletics/fl-application-android/pull/11237).